### PR TITLE
Add civic.json default file

### DIFF
--- a/content/default-files/civic.json
+++ b/content/default-files/civic.json
@@ -1,0 +1,5 @@
+{
+  "status": "Ideation",
+  "bornAt": "Code for Denver",
+  "tags": []
+}


### PR DESCRIPTION
#### What does this PR do?

Adds a default civic.json file to new projects for the Code for America API

What is a civic.json file?

> Civic.json is a metadata standard for civic technology projects that is intended to complement project information in a github repository.

See https://github.com/codeforamerica/cfapi\#civicjson and
https://github.com/BetaNYC/civic.json for context
#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](http://i.giphy.com/NmGbJwLl7Y4lG.gif)
